### PR TITLE
add is_datatype_expr

### DIFF
--- a/src/Expronicon.jl
+++ b/src/Expronicon.jl
@@ -11,7 +11,7 @@ export
     # analysis
     @expr, @test_expr, compare_expr, compare_vars,
     AnalysisError, is_function, is_kw_function, is_struct,
-    is_ifelse, is_for, is_field, is_field_default,
+    is_ifelse, is_for, is_field, is_field_default, is_datatype_expr,
     split_function, split_function_head, split_struct,
     split_struct_name, split_ifelse,
     uninferrable_typevars, has_symbol,

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -373,6 +373,22 @@ function is_field_default(@nospecialize(ex))
 end
 
 """
+    is_datatype_expr(ex)
+
+Check if `ex` is an expression for a concrete `DataType`, e.g
+`where` is not allowed in the expression.
+"""
+function is_datatype_expr(@nospecialize(ex))
+    @match ex begin
+        ::Symbol => true
+        ::GlobalRef => true
+        :($_{$_...}) => true
+        :($_.$b) => is_datatype_expr(b)
+        _ => false
+    end
+end
+
+"""
     split_doc(ex::Expr) -> line, doc, expr
 
 Split doc string from given expression.

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -6,6 +6,14 @@ using Expronicon
     @test is_function(:(x -> 2x))
 end
 
+@testset "is_datatype_expr" begin
+    @test is_datatype_expr(:name)
+    @test is_datatype_expr(GlobalRef(Main, :name))
+    @test is_datatype_expr(:(Main.Reflected.OptionA))
+    @test is_datatype_expr(:(struct Foo end)) == false
+    @test is_datatype_expr(:(Foo{T} where T)) == false
+end
+
 @testset "uninferrable_typevars" begin
     def = @expr JLKwStruct struct Inferable1{T}
         x::Constaint{T, <(2)}


### PR DESCRIPTION
this function checks if the given expression is a data type expression, this is useful when one wants to parse a string that is supposed to be a data type expression, e.g in Configurations parsing the corresponding string value of Reflect type