### PR TITLE
support using ADT variant inside ADT definition

### DIFF
--- a/src/Expronicon.jl
+++ b/src/Expronicon.jl
@@ -22,9 +22,9 @@ export
     has_plain_constructor,
     guess_type,
     # transformations
-    no_default, prettify, rm_lineinfo, flatten_blocks, name_only,
+    Substitute, no_default, prettify, rm_lineinfo, flatten_blocks, name_only,
     annotations_only, rm_annotations, rm_single_block, rm_nothing,
-    replace_symbol, subtitute, eval_interp, eval_literal,
+    substitute, eval_interp, eval_literal,
     expr_map, nexprs,
     # codegen
     codegen_ast,

--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -1,28 +1,100 @@
+mutable struct VariantFieldTypes
+    expr::Vector{Any}
+    mask::Vector{Int}
+    guess::Vector{Any}
+    variant_types::Vector{Vector{Any}}
+
+    VariantFieldTypes() = new()
+end
+
 struct EmitInfo
     typename::Symbol
     ismutable::Bool
     fieldnames::Vector{Symbol}
     fieldtypes::Vector{Any}
-    variant_masks::Dict{Variant, Vector{Int}} # variant masks
-    type_guess::Dict{Variant, Vector{Any}}
+
+    typeinfo::Dict{Variant, VariantFieldTypes}
+    variant_names::Vector{Symbol}
+    name_type_map::Dict{Symbol, UInt32}
+    # contains_variant::Vector{Bool}
+    # variant_masks::Dict{Variant, Vector{Int}} # variant masks
+    # type_guess::Dict{Variant, Vector{Any}}
 end
 
-function EmitInfo(typename::Symbol, ismutable::Bool=false)
+function EmitInfo(typename::Symbol, variant_names::Vector{Symbol}, ismutable::Bool=false)
     return EmitInfo(
         typename, ismutable,
-        Symbol[], [],
-        Dict{Variant, Vector{Int}}(),
-        Dict{Variant, Vector{Any}}()
+        Symbol[], [], Dict{Variant, VariantFieldTypes}(),
+        variant_names, Dict{Symbol, UInt}(),
     )
 end
 
+function assign_type!(info::EmitInfo, def::ADTTypeDef)
+    for (idx, variant) in enumerate(def.variants)
+        info.name_type_map[variant.name] = UInt32(idx)
+    end
+    return info
+end
+
 function guess_type!(info::EmitInfo, def::ADTTypeDef)
+    function change_type(expr)
+        @switch expr begin
+            @case ::Symbol
+                expr in info.variant_names && return def.name
+                return expr
+            @case :(Union{$(types...)}) || :(&Union{$(types...)})
+                types = map(types) do type
+                    type in info.variant_names && return def.name
+                    return type
+                end
+                return Expr(:curly, :Union, types...)
+            @case ::Expr
+                return Expr(expr.head, map(change_type, expr.args)...)
+            @case _
+                return expr
+        end
+    end
+
     for variant in def.variants
-        info.type_guess[variant] = map(variant.fieldtypes) do type
-            guess_type(def.m, type)
+        typeinfo = get!(VariantFieldTypes, info.typeinfo, variant)
+        typeinfo.guess = map(variant.fieldtypes) do type
+            guess_type(def.m, change_type(type))
+        end
+        typeinfo.expr = variant.fieldtypes
+    end
+    return info
+end
+
+function scan_variant_types!(info::EmitInfo, def::ADTTypeDef)
+    for variant in def.variants
+        typeinfo = get!(VariantFieldTypes, info.typeinfo, variant)
+        typeinfo.variant_types = Vector{Vector{Any}}(undef, length(variant.fieldtypes))
+        for (idx, expr) in enumerate(variant.fieldtypes)
+            list = scan_field_variant_types!([], expr, info.variant_names)
+            typeinfo.variant_types[idx] = list
         end
     end
     return info
+end
+
+# NOTE: we ignore Foo{VariantType} since we cannot actually check it
+function scan_field_variant_types!(list::Vector{Any}, expr, variant_names::Vector{Symbol})
+    @switch expr begin
+        @case ::Symbol
+            expr in variant_names && push!(list, expr)
+        @case :(Union{$(types...)}) || :(&Union{$(types...)})
+            for type in types
+                scan_field_variant_types!(list, type, variant_names)
+            end
+        # @case :($name{$(types...)}) # Foo{VariantType}
+        #     contains_variant_type(types, variant_names) && push!(list, expr)
+        # Foo{VariantType, A} where VariantType, just happen to have the same name
+        @case Expr(:where, type, params)
+            type = Expronicon.mark_typevars(type, name_only.(params))
+            scan_field_variant_types!(list, type, variant_names)
+        @case _
+    end
+    return list
 end
 
 function scan_fields!(info::EmitInfo, def::ADTTypeDef)
@@ -30,7 +102,7 @@ function scan_fields!(info::EmitInfo, def::ADTTypeDef)
 
     for variant in def.variants
         variant_type_set = Dict{Any, Int}()
-        for type in info.type_guess[variant]
+        for type in info.typeinfo[variant].guess
             if isbitstype(type)
                 variant_type_set[type] = get(variant_type_set, type, 0) + 1
             else
@@ -78,10 +150,10 @@ function scan_fields!(info::EmitInfo, def::ADTTypeDef)
     end
 
     for variant in def.variants
-        mask = info.variant_masks[variant] =
-            Vector{Int}(undef, length(variant.fieldtypes))
+        typeinfo = get!(VariantFieldTypes, info.typeinfo, variant)
+        mask = typeinfo.mask = Vector{Int}(undef, length(variant.fieldtypes))
         variant_type_ptr = Dict{Any, Int}()
-        for (idx, type) in enumerate(info.type_guess[variant])
+        for (idx, type) in enumerate(typeinfo.guess)
             if isbitstype(type)
                 variant_type_ptr[type] = get(variant_type_ptr, type, 0) + 1
                 mask[idx] = type_start[type] + variant_type_ptr[type] - 1
@@ -96,9 +168,17 @@ end
 
 function EmitInfo(def::ADTTypeDef)
     ismutable = any(x->x.ismutable, def.variants)
-    info = EmitInfo(Symbol(def.name, "#Type"), ismutable)
+    variant_names = map(def.variants) do variant
+        return variant.name
+    end
+    info = EmitInfo(Symbol(def.name, "#Type"), variant_names, ismutable)
+    # replace variant type in field types with
+    # the actual type. Then add a dynamic type check
+    # in the constructor.
+    assign_type!(info, def)
     guess_type!(info, def)
     scan_fields!(info, def)
+    scan_variant_types!(info, def)
     return info
 end
 
@@ -157,8 +237,7 @@ function emit_variant_binding(def::ADTTypeDef, info::EmitInfo)
 end
 
 function struct_cons(def::ADTTypeDef, info::EmitInfo)
-    construct_body = JLIfElse()
-    for (variant_idx, variant) in enumerate(def.variants)
+    construct_body = foreach_variant_type(:type, def, info) do variant
         nargs = length(variant.fieldtypes)
         msg = :("expect $($nargs) arguments, got $(length(args)) arguments")
 
@@ -168,23 +247,56 @@ function struct_cons(def::ADTTypeDef, info::EmitInfo)
             new_head = :(new{$(name_only.(def.typevars)...)})
         end
 
-        args = Vector{Any}(undef, length(info.fieldtypes))
-        args[1] = :type
+        args = map(eachindex(info.fieldtypes)) do idx
+            idx == 1 && return :type
+            return Symbol("#args#", idx)
+        end
 
-        arg_ptr = 1
-        for idx in 2:length(info.fieldtypes)
-            if idx in info.variant_masks[variant]
-                args[idx] = :(args[$arg_ptr])
+        arg_ptr = 0
+        assert_args = expr_map(2:length(info.fieldtypes)) do idx
+            typeinfo = info.typeinfo[variant]
+            if idx in typeinfo.mask
                 arg_ptr += 1
+                argname = args[idx]
+                vtypenames = typeinfo.variant_types[arg_ptr]
+                type_guess = typeinfo.guess[arg_ptr]
+                jl = JLIfElse()
+                if !isempty(vtypenames)
+                    @gensym variant_type
+                    msg = "expect $(join(vtypenames, " or "))"
+                    vtypes = map(vtypenames) do t
+                        :(Core.bitcast($(info.typename), $(info.name_type_map[t])))
+                    end
+                    jl[:(args[$arg_ptr] isa $(def.name))] = quote
+                        $argname = args[$arg_ptr]
+                        $variant_type = $ADT.variant_type($argname)
+                        $variant_type in $(xtuple(vtypes...)) || throw(ArgumentError(
+                            "$($msg), got $($variant_type)"))
+                    end
+
+                    if type_guess !== def.name
+                        jl[:(args[$arg_ptr] isa $type_guess)] = quote
+                            $argname = args[$arg_ptr]
+                        end
+                    end
+                else
+                    jl[:(args[$arg_ptr] isa $type_guess)] = quote
+                        $argname = args[$arg_ptr]
+                    end
+                end
+
+                jl.otherwise = quote
+                    $argname = $Base.convert($type_guess, args[$arg_ptr])
+                end
+                codegen_ast(jl)
             else
-                args[idx] = undef_value(info.fieldtypes[idx])
+                :($(args[idx]) = $(undef_value(info.fieldtypes[idx])))
             end
         end
 
-        type_expr = xvariant_type(info, variant_idx)
-        construct_body[:(type == $(type_expr))] = quote
-            length(args) == $nargs ||
-                throw(ArgumentError($msg))
+        return quote
+            length(args) == $nargs || throw(ArgumentError($msg))
+            $assert_args
             $new_head($(args...))
         end
     end
@@ -272,7 +384,7 @@ function emit_getproperty(def::ADTTypeDef, info::EmitInfo)
             end
         else
             jl = JLIfElse()
-            mask = info.variant_masks[variant]
+            mask = info.typeinfo[variant].mask
             for (idx, field) in enumerate(variant.fieldnames)
                 jl[:(name === $(QuoteNode(field)))] = quote
                     # annotate type to avoid type instability

--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -154,7 +154,7 @@ function scan_fields!(info::EmitInfo, def::ADTTypeDef)
         mask = typeinfo.mask = Vector{Int}(undef, length(variant.fieldtypes))
         variant_type_ptr = Dict{Any, Int}()
         for (idx, type) in enumerate(typeinfo.guess)
-            if isbitstype(type)
+            if type isa Type && isbitstype(type)
                 variant_type_ptr[type] = get(variant_type_ptr, type, 0) + 1
                 mask[idx] = type_start[type] + variant_type_ptr[type] - 1
             else

--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -385,10 +385,11 @@ function emit_getproperty(def::ADTTypeDef, info::EmitInfo)
         else
             jl = JLIfElse()
             mask = info.typeinfo[variant].mask
+            type_guess = info.typeinfo[variant].guess
             for (idx, field) in enumerate(variant.fieldnames)
                 jl[:(name === $(QuoteNode(field)))] = quote
                     # annotate type to avoid type instability
-                    return $Base.getfield(value, $(mask[idx]))::$(variant.fieldtypes[idx])
+                    return $Base.getfield(value, $(mask[idx]))::$(type_guess[idx])
                 end
             end
             jl.otherwise = quote

--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -103,7 +103,7 @@ function scan_fields!(info::EmitInfo, def::ADTTypeDef)
     for variant in def.variants
         variant_type_set = Dict{Any, Int}()
         for type in info.typeinfo[variant].guess
-            if isbitstype(type)
+            if type isa Type && isbitstype(type)
                 variant_type_set[type] = get(variant_type_set, type, 0) + 1
             else
                 variant_type_set[Any] = get(variant_type_set, Any, 0) + 1

--- a/src/adt/print.jl
+++ b/src/adt/print.jl
@@ -91,10 +91,12 @@ function Base.show(io::IO, ::MIME"text/plain", info::EmitInfo)
         println(io)
     end
 
+    isempty(info.typeinfo) && return
+
     println(io)
     println(io, tab(2), "variants:")
 
-    variants = sort(collect(keys(info.variant_masks)); by=x->x.name)
+    variants = sort(collect(keys(info.typeinfo)); by=x->x.name)
 
     # find max line width
     variant_lines_nocolor = map(variants) do variant
@@ -115,7 +117,7 @@ function Base.show(io::IO, ::MIME"text/plain", info::EmitInfo)
         lines = splitlines(String(take!(buf))) # lines with color
         padding = max_line_width - length(variant_lines_nocolor[idx][1]) + 4
 
-        mask = info.variant_masks[variant]
+        mask = info.typeinfo[variant].mask
         print(io, tab(4), lines[1], tab(1))
         printstyled(io, '-'^(padding-2); color=:light_black)
 

--- a/src/adt/reflection.jl
+++ b/src/adt/reflection.jl
@@ -41,7 +41,7 @@ end
 
 function emit_variant_masks(def::ADTTypeDef, info::EmitInfo)
     body = foreach_variant_type(:t, def, info) do variant
-        xtuple(info.variant_masks[variant]...)
+        xtuple(info.typeinfo[variant].mask...)
     end
 
     return quote

--- a/src/analysis/compare.jl
+++ b/src/analysis/compare.jl
@@ -271,15 +271,9 @@ function compare_where(m::Module, lhs::Expr, rhs::Expr)
 end
 
 function mark_typevars(expr, typevars::Vector{Symbol})
-    if expr isa Symbol
-        if expr in typevars
-            return Variable(expr)
-        else
-            return expr
-        end
-    elseif expr isa Expr
-        return Expr(expr.head, map(x -> mark_typevars(x, typevars), expr.args)...)
-    else
-        return expr
+    sub = Substitute() do expr
+        expr isa Symbol && expr in typevars && return true
+        return false
     end
+    return sub(Variable, expr)
 end

--- a/src/analysis/guess.jl
+++ b/src/analysis/guess.jl
@@ -45,7 +45,10 @@ function guess_type(m::Module, ex)
                 guess_type(m, typevar)
             end
 
-            if type isa Type && all(is_valid_typevar, typevars)
+            if type === Union
+                all(x->isa(x,Type), typevars) || return ex
+                return Union{typevars...}
+            elseif type isa Type && all(is_valid_typevar, typevars)
                 return type{typevars...}
             else
                 return ex

--- a/src/expand.jl
+++ b/src/expand.jl
@@ -17,14 +17,6 @@ function rm_include(paths::Vector{String}, ex)
     return ex
 end
 
-function substitute(f, ex, new)
-    @match ex begin
-        GuardBy(f) => new
-        Expr(head, args...) => Expr(head, map(x->substitute(f, x, new), args)...)
-        _ => ex
-    end
-end
-
 function rm_using(name::Symbol, ex)
     @match ex begin
         :(using $(&name)) => nothing
@@ -207,7 +199,7 @@ function expand_file(src, dst, options::ExpandOptions, excluded_paths = file_to_
     @info "substitute module identifier"
     old_mod = options.project
     new_mod = Symbol(options.project, options.postfix)
-    ex = subtitute(ex, old_mod=>new_mod)
+    ex = substitute(ex, old_mod=>new_mod)
     ex = expand_macro(options.mod, ex; macronames=options.macronames)
 
     rel_excluded_paths = map(excluded_paths) do path
@@ -222,7 +214,7 @@ function expand_file(src, dst, options::ExpandOptions, excluded_paths = file_to_
     ex = _insert_include_generated(ex)
     ex = _replace_include(ex, options)
     ex = prettify(ex)
-    ex = subtitute(ex, old_mod=>new_mod)
+    ex = substitute(ex, old_mod=>new_mod)
 
     open(dst, "w+") do io
         println(IOContext(io, :module=>Expronicon), ex)

--- a/test/adt/emit.jl
+++ b/test/adt/emit.jl
@@ -430,3 +430,55 @@ end
         return
     end
 end
+
+
+using Expronicon.ADT: @adt
+@adt MubanLang begin
+    # reference to a Julia variable
+    Id(::Symbol)
+
+    # <object>.<fieldname>
+    struct Reference
+        object::Union{Id, Reference} # Id or Reference
+        fieldname::MubanLang # Id
+    end
+end
+
+body = quote
+    None
+    # reference to a Julia variable
+    Id(::Symbol)
+
+    # <object>.<fieldname>
+    struct Reference
+        object::Union{Id, Reference} # Id or Reference
+        fieldname::MubanLang # Id
+        some::None
+    end
+end
+def = ADTTypeDef(Main, :MubanLang, body)
+info = EmitInfo(def)
+emit_struct(def, info)
+
+@adt Message begin
+    # quit the program
+    Quit
+    # move the cursor to (x, y)
+    Move(::Int64, ::Int64)
+end
+
+@adt MubanLang begin
+    None
+    # reference to a Julia variable
+    Id(::Symbol)
+
+    # <object>.<fieldname>
+    struct Reference
+        object::Union{Id, Reference} # Id or Reference
+        fieldname::MubanLang # Id
+        some::None
+    end
+end
+
+Reference(Id(:x), Id(:y), None)
+MubanLang(Reference, Id(:x), Id(:y), None)

--- a/test/adt/emit.jl
+++ b/test/adt/emit.jl
@@ -44,11 +44,11 @@ end
 @testset "EmitInfo(::ADTTypeDef)" begin
     def = ADTTypeDef(Main, :Message, body)
     info = EmitInfo(def)
-    @test info.variant_masks[def.variants[1]] == Int[]
-    @test info.variant_masks[def.variants[2]] == [2, 3]
-    @test info.variant_masks[def.variants[3]] == [5]
-    @test info.variant_masks[def.variants[4]] == [5, 6]
-    @test info.variant_masks[def.variants[5]] == [2, 3, 4]
+    @test info.typeinfo[def.variants[1]].mask == Int[]
+    @test info.typeinfo[def.variants[2]].mask == [2, 3]
+    @test info.typeinfo[def.variants[3]].mask == [5]
+    @test info.typeinfo[def.variants[4]].mask == [5, 6]
+    @test info.typeinfo[def.variants[5]].mask == [2, 3, 4]
 
     @test info.fieldtypes == [Symbol("Message#Type"), Int64, Int64, Int64, Any, Any]
     @test length(info.fieldnames) == 6
@@ -85,32 +85,91 @@ def = ADTTypeDef(Main, :Message, body)
 info = EmitInfo(def)
 
 @test_expr emit_struct(def, info) == quote
-    Core.@__doc__ struct Message
-        var"#type"::var"Message#Type"
-        var"#Int64##2"::Int64
-        var"#Int64##3"::Int64
-        var"#Int64##4"::Int64
-        var"#Any##5"
-        var"#Any##6"
-        function Message(type::var"Message#Type", args...)
-            if type == Core.bitcast(var"Message#Type", 0x00000001)
-                length(args) == 0 || throw(ArgumentError("expect $(0) arguments, got $(length(args)) arguments"))
-                new(type, 0, 0, 0, nothing, nothing)
-            elseif type == Core.bitcast(var"Message#Type", 0x00000002)
-                length(args) == 2 || throw(ArgumentError("expect $(2) arguments, got $(length(args)) arguments"))
-                new(type, args[1], args[2], 0, nothing, nothing)
-            elseif type == Core.bitcast(var"Message#Type", 0x00000003)
-                length(args) == 1 || throw(ArgumentError("expect $(1) arguments, got $(length(args)) arguments"))
-                new(type, 0, 0, 0, args[1], nothing)
-            elseif type == Core.bitcast(var"Message#Type", 0x00000004)
-                length(args) == 2 || throw(ArgumentError("expect $(2) arguments, got $(length(args)) arguments"))
-                new(type, 0, 0, 0, args[1], args[2])
-            elseif type == Core.bitcast(var"Message#Type", 0x00000005)
-                length(args) == 3 || throw(ArgumentError("expect $(3) arguments, got $(length(args)) arguments"))
-                new(type, args[1], args[2], args[3], nothing, nothing)
+    #= /Users/roger/Code/Julia/Expronicon/src/adt/emit.jl:329 =# Core.@__doc__ struct Message
+            var"#type"::var"Message#Type"
+            var"#Int64##2"::Int64
+            var"#Int64##3"::Int64
+            var"#Int64##4"::Int64
+            var"#Any##5"
+            var"#Any##6"
+            function Message(type::var"Message#Type", args...)
+                if type == Core.bitcast(var"Message#Type", 0x00000001)
+                    length(args) == 0 || throw(ArgumentError("expect $(0) arguments, got $(length(args)) arguments"))
+                    var"#args#2" = 0
+                    var"#args#3" = 0
+                    var"#args#4" = 0
+                    var"#args#5" = nothing
+                    var"#args#6" = nothing
+                    new(type, var"#args#2", var"#args#3", var"#args#4", var"#args#5", var"#args#6")
+                elseif type == Core.bitcast(var"Message#Type", 0x00000002)
+                    length(args) == 2 || throw(ArgumentError("expect $(2) arguments, got $(length(args)) arguments"))
+                    if args[1] isa Int64
+                        var"#args#2" = args[1]
+                    else
+                        var"#args#2" = (Base).convert(Int64, args[1])
+                    end
+                    if args[2] isa Int64
+                        var"#args#3" = args[2]
+                    else
+                        var"#args#3" = (Base).convert(Int64, args[2])
+                    end
+                    var"#args#4" = 0
+                    var"#args#5" = nothing
+                    var"#args#6" = nothing
+                    new(type, var"#args#2", var"#args#3", var"#args#4", var"#args#5", var"#args#6")
+                elseif type == Core.bitcast(var"Message#Type", 0x00000003)
+                    length(args) == 1 || throw(ArgumentError("expect $(1) arguments, got $(length(args)) arguments"))
+                    var"#args#2" = 0
+                    var"#args#3" = 0
+                    var"#args#4" = 0
+                    if args[1] isa String
+                        var"#args#5" = args[1]
+                    else
+                        var"#args#5" = (Base).convert(String, args[1])
+                    end
+                    var"#args#6" = nothing
+                    new(type, var"#args#2", var"#args#3", var"#args#4", var"#args#5", var"#args#6")
+                elseif type == Core.bitcast(var"Message#Type", 0x00000004)
+                    length(args) == 2 || throw(ArgumentError("expect $(2) arguments, got $(length(args)) arguments"))
+                    var"#args#2" = 0
+                    var"#args#3" = 0
+                    var"#args#4" = 0
+                    if args[1] isa Vector{Int64}
+                        var"#args#5" = args[1]
+                    else
+                        var"#args#5" = (Base).convert(Vector{Int64}, args[1])
+                    end
+                    if args[2] isa Vector{Int64}
+                        var"#args#6" = args[2]
+                    else
+                        var"#args#6" = (Base).convert(Vector{Int64}, args[2])
+                    end
+                    new(type, var"#args#2", var"#args#3", var"#args#4", var"#args#5", var"#args#6")
+                elseif type == Core.bitcast(var"Message#Type", 0x00000005)
+                    length(args) == 3 || throw(ArgumentError("expect $(3) arguments, got $(length(args)) arguments"))
+                    if args[1] isa Int64
+                        var"#args#2" = args[1]
+                    else
+                        var"#args#2" = (Base).convert(Int64, args[1])
+                    end
+                    if args[2] isa Int64
+                        var"#args#3" = args[2]
+                    else
+                        var"#args#3" = (Base).convert(Int64, args[2])
+                    end
+                    if args[3] isa Int64
+                        var"#args#4" = args[3]
+                    else
+                        var"#args#4" = (Base).convert(Int64, args[3])
+                    end
+                    var"#args#5" = nothing
+                    var"#args#6" = nothing
+                    new(type, var"#args#2", var"#args#3", var"#args#4", var"#args#5", var"#args#6")
+                else
+                    throw(ArgumentError("invalid variant type"))
+                end
             end
         end
-    end
 end
 
 @test_expr emit_variant_cons(def, info) == quote
@@ -211,7 +270,6 @@ end
         end
     end
 end
-emit_reflection(def, info)
 
 @test_expr emit_variants(def, info) == quote
     function (Expronicon.ADT).variants(::Type{<:Message})
@@ -432,41 +490,6 @@ end
 end
 
 
-using Expronicon.ADT: @adt
-@adt MubanLang begin
-    # reference to a Julia variable
-    Id(::Symbol)
-
-    # <object>.<fieldname>
-    struct Reference
-        object::Union{Id, Reference} # Id or Reference
-        fieldname::MubanLang # Id
-    end
-end
-
-body = quote
-    None
-    # reference to a Julia variable
-    Id(::Symbol)
-
-    # <object>.<fieldname>
-    struct Reference
-        object::Union{Id, Reference} # Id or Reference
-        fieldname::MubanLang # Id
-        some::None
-    end
-end
-def = ADTTypeDef(Main, :MubanLang, body)
-info = EmitInfo(def)
-emit_struct(def, info)
-
-@adt Message begin
-    # quit the program
-    Quit
-    # move the cursor to (x, y)
-    Move(::Int64, ::Int64)
-end
-
 @adt MubanLang begin
     None
     # reference to a Julia variable
@@ -480,5 +503,7 @@ end
     end
 end
 
-Reference(Id(:x), Id(:y), None)
-MubanLang(Reference, Id(:x), Id(:y), None)
+@testset "variant as field type" begin
+    @test Reference(Id(:x), Id(:y), None).some == None
+    @test_throws ArgumentError Reference(None, Id(:y), None)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,5 +55,3 @@ end
 
 DocMeta.setdocmeta!(Expronicon, :DocTestSetup, :(using Expronicon); recursive=true)
 doctest(Expronicon)
-
-@macroexpand @test 1 + x

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -106,9 +106,9 @@ end
     end))
 end
 
-@testset "subtitute" begin
-    @test subtitute(:(x + 1), :x=>:y) == :(y + 1)
-    @test subtitute(:(for i in 1:10;x += i;end), :x => :y) == :(for i in 1:10;y += i;end)
+@testset "substitute" begin
+    @test substitute(:(x + 1), :x=>:y) == :(y + 1)
+    @test substitute(:(for i in 1:10;x += i;end), :x => :y) == :(for i in 1:10;y += i;end)
 end
 
 @testset "expr_map" begin


### PR DESCRIPTION
```julia
@adt MubanLang begin
    None
    # reference to a Julia variable
    Id(::Symbol)

    # <object>.<fieldname>
    struct Reference
        object::Union{Id, Reference} # Id or Reference
        fieldname::MubanLang # Id
        some::None
    end
end
```