### PR TITLE
stop overloading show

### DIFF
--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -195,13 +195,13 @@ end
 
 Create an algebra data type (ADT).
 
-# Arguments
+### Arguments
 
 - `public`: optional, if present, the ADT and its variants will be exported.
 - `<name>`: the name of the ADT, can be just a name or name with supertype.
 - `<body>`: the body of the ADT, a list of variants in `begin ... end` block.
 
-# Introduction
+### Introduction
 
 The ADT is a type that can have multiple
 variants. Each variant can have different fields. The fields can be of different
@@ -217,6 +217,12 @@ Use of multiple variants will not effect type stability, unlike `Union` types.
 The variants must be used with the variant interface instead of the type interface
 from Julia `Base`, and the pattern match must be MLStyle's pattern match. It is
 recommended to use pattern match as much as possible.
+
+### Pretty Printing
+
+A default pretty printing method is provided for the ADT as `ADT.default_show`.
+One should overload the `Base.show` method call `ADT.default_show` if the default
+pretty printing is preferred.
 """
 macro adt(head, body)
     def = ADTTypeDef(__module__, head, body)

--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -475,11 +475,11 @@ function emit_show(def::ADTTypeDef, info::EmitInfo)
     show_body = foreach_variant(:t, def, info) do variant
         if variant.type === :singleton
             quote
-                $Base.show(io, $value_type)
+                $ADT.default_show(io, $value_type)
             end
         elseif variant.type === :call
             quote
-                $Base.show(io, $value_type)
+                $ADT.default_show(io, $value_type)
                 print(io, "(")
                 mask = $ADT.variant_masks($value_type)
                 for (idx, field_idx) in enumerate(mask)
@@ -493,7 +493,7 @@ function emit_show(def::ADTTypeDef, info::EmitInfo)
             end
         else # struct
             quote
-                $Base.show(io, $value_type)
+                $ADT.default_show(io, $value_type)
                 print(io, "(")
                 mask = $ADT.variant_masks($value_type)
                 names = $ADT.variant_fieldnames($value_type)
@@ -511,7 +511,7 @@ function emit_show(def::ADTTypeDef, info::EmitInfo)
     end
 
     return quote
-        function Base.show(io::IO, t::$(def.name))
+        function $ADT.default_show(io::IO, t::$(def.name))
             $(codegen_ast(show_body))
         end
     end

--- a/src/adt/print.jl
+++ b/src/adt/print.jl
@@ -1,6 +1,16 @@
 tab(n) = " "^n
 splitlines(s::String) = split(s, '\n')
 
+"""
+    default_show(io::IO, x)
+
+The default `show` method for an ADT. This is used to print the ADT.
+"""
+function default_show(io::IO, x)
+    is_variant(x) || throw(ArgumentError("not an ADT variant: $x"))
+    return show(io, x)
+end
+
 function Base.show(io::IO, mime::MIME"text/plain", def::ADTTypeDef)
     printstyled(io, "@adt "; color=:cyan)
     def.export_variants && printstyled(io, "public "; color=197)

--- a/src/adt/reflection.jl
+++ b/src/adt/reflection.jl
@@ -1,5 +1,10 @@
 function emit_reflection(def::ADTTypeDef, info::EmitInfo)
     quote
+        $ADT.is_variant(::$(info.typename)) = true
+        $ADT.is_variant(::$(def.name)) = true
+        $ADT.is_adt(::Type{<:$(def.name)}) = true
+        $ADT.is_adt(::$(def.name)) = true
+
         $(emit_variants(def, info))
         $(emit_adt_type(def, info))
         $(emit_variant_type(def, info))

--- a/src/adt/traits.jl
+++ b/src/adt/traits.jl
@@ -1,4 +1,26 @@
 """
+    is_adt(::Type{T}) where T
+
+Returns `true` if `T` is an algebra data type.
+"""
+is_adt(::Type{T}) where T = false
+
+"""
+    is_adt(variant)
+
+Returns `true` if `variant` is an instance of an algebra data type.
+"""
+is_adt(variant) = false
+
+"""
+    is_variant(variant)
+    is_variant(variant_type)
+
+Returns `true` if `T` is a variant type or an instance of an algebra data type.
+"""
+is_variant(variant_type) = false
+
+"""
     variants(::Type{T}) where T
 
 Returns the variant types of an algebra data type `T`.

--- a/test/adt/emit.jl
+++ b/test/adt/emit.jl
@@ -215,11 +215,11 @@ end
 end
 
 @test_expr emit_show(def, info) == quote
-    function Base.show(io::IO, t::Message)
+    function $ADT.default_show(io::IO, t::Message)
         if (Expronicon.ADT).variant_type(t) == Core.bitcast(var"Message#Type", 0x00000001)
-            (Base).show(io, (Expronicon.ADT).variant_type(t))
+            ADT.default_show(io, (Expronicon.ADT).variant_type(t))
         elseif (Expronicon.ADT).variant_type(t) == Core.bitcast(var"Message#Type", 0x00000002)
-            (Base).show(io, (Expronicon.ADT).variant_type(t))
+            ADT.default_show(io, (Expronicon.ADT).variant_type(t))
             print(io, "(")
             mask = (Expronicon.ADT).variant_masks((Expronicon.ADT).variant_type(t))
             names = (Expronicon.ADT).variant_fieldnames((Expronicon.ADT).variant_type(t))
@@ -232,7 +232,7 @@ end
             end
             print(io, ")")
         elseif (Expronicon.ADT).variant_type(t) == Core.bitcast(var"Message#Type", 0x00000003)
-            (Base).show(io, (Expronicon.ADT).variant_type(t))
+            ADT.default_show(io, (Expronicon.ADT).variant_type(t))
             print(io, "(")
             mask = (Expronicon.ADT).variant_masks((Expronicon.ADT).variant_type(t))
             for (idx, field_idx) = enumerate(mask)
@@ -243,7 +243,7 @@ end
             end
             print(io, ")")
         elseif (Expronicon.ADT).variant_type(t) == Core.bitcast(var"Message#Type", 0x00000004)
-            (Base).show(io, (Expronicon.ADT).variant_type(t))
+            ADT.default_show(io, (Expronicon.ADT).variant_type(t))
             print(io, "(")
             mask = (Expronicon.ADT).variant_masks((Expronicon.ADT).variant_type(t))
             names = (Expronicon.ADT).variant_fieldnames((Expronicon.ADT).variant_type(t))
@@ -256,7 +256,7 @@ end
             end
             print(io, ")")
         elseif (Expronicon.ADT).variant_type(t) == Core.bitcast(var"Message#Type", 0x00000005)
-            (Base).show(io, (Expronicon.ADT).variant_type(t))
+            ADT.default_show(io, (Expronicon.ADT).variant_type(t))
             print(io, "(")
             mask = (Expronicon.ADT).variant_masks((Expronicon.ADT).variant_type(t))
             for (idx, field_idx) = enumerate(mask)


### PR DESCRIPTION
This PR stops overloading the `Base.show(io, x)` method and overloads the `ADT.default_show(io, x)` instead. One should manually overload `Base.show(io, x)` if one wants to use the default show printing.

cc: @weinbe58