### PR TITLE
Inline tree printer for ADT

### DIFF
--- a/src/print/tree.jl
+++ b/src/print/tree.jl
@@ -142,7 +142,7 @@ function print_node(io::IO, node)
     error("unimplemented print_node method for $(typeof(node))")
 end    
 function print_child_annotation(io::IO, node, child, annotation)
-    error("unimplemented print_child_key method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
+    error("unimplemented print_child_annotation method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
 end
 
 should_print_annotation(ch) = applicable(keys, ch)
@@ -235,7 +235,7 @@ children(node) = error("unimplemented children method for $(typeof(node))")
 print_node(io::IO, node) = error("unimplemented print_node method for $(typeof(node))")
 print_node_suffix(io::IO, node) = return
 
-print_child_annotation(io::IO, node, child, annotation) = error("unimplemented print_annotation_after method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
+print_child_annotation(io::IO, node, child, annotation) = error("unimplemented print_annotation method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
 print_child_annotation_suffix(io::IO, node, child, annotation) = return
 
 precedence(node) = 1

--- a/src/print/tree.jl
+++ b/src/print/tree.jl
@@ -1,7 +1,6 @@
 module Tree
 
-using MLStyle: @match
-using ..Expronicon: mapjoin
+module Multiline
 
 # this is adapted from AbstractTree since
 # we need the printing frequently but it kept
@@ -57,13 +56,13 @@ function (p::Printer)(node)
     print(xs...) = Base.print(p.io, xs...)
     println(xs...) = Base.println(p.io, xs...)
     printstyled(xs...; kw...) = Base.printstyled(p.io, xs...; kw...)
+    print_child_annotation(node, child, key) = Multiline.print_child_annotation(p.io, node, child, key)
 
-    children = Tree.children(node)
-    node_str = sprint(Tree.print_node, node, context=IOContext(p.io))
+    children = Multiline.children(node)
+    node_str = sprint(Multiline.print_node, node, context=IOContext(p.io))
     for (i, line) in enumerate(split(node_str, '\n'))
         i ≠ 1 && print(prefix)
         print(line)
-        # println()
         if !(p.state.last && isempty(children))
             println()
         end
@@ -74,15 +73,15 @@ function (p::Printer)(node)
         return
     end
 
-    this_printkeys = should_printkeys(children)
+    this_print_annotation = should_print_annotation(children)
 
     s = Iterators.Stateful(
-        this_printkeys ? pairs(children) : children
+        this_print_annotation ? pairs(children) : children
     )
     while !isempty(s)
         child_prefix = p.state.prefix
-        if this_printkeys
-            key, child = popfirst!(s)
+        if this_print_annotation
+            child, key = popfirst!(s)
         else
             child = popfirst!(s)
             key = nothing
@@ -114,9 +113,9 @@ function (p::Printer)(node)
 
         print(p.charset.dash, ' ')
 
-        if this_printkeys
-            key_str = sprint(print_child_key, key)
-            printstyled(key_str, color=p.color.key)
+        if this_print_annotation
+            key_str = sprint(Multiline.print_child_annotation, node, child, key)
+            print_child_annotation(node, child, key)
             print(p.charset.pair)
 
             child_prefix *= " " ^ (
@@ -136,20 +135,123 @@ function (p::Printer)(node)
     end
 end
 
-function print_node(io::IO, node)
-    error("unimplemented print_node method for $(typeof(node))")
-end
-
 function children(node)
     error("unimplemented children method for $(typeof(node))")
 end
+function print_node(io::IO, node)
+    error("unimplemented print_node method for $(typeof(node))")
+end    
+function print_child_annotation(io::IO, node, child, annotation)
+    error("unimplemented print_child_key method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
+end
 
-should_printkeys(ch) = applicable(keys, ch)
-should_printkeys(::AbstractVector) = false
-should_printkeys(::Tuple) = false
-should_printkeys(::Base.Generator) = false
+should_print_annotation(ch) = applicable(keys, ch)
+should_print_annotation(::AbstractVector) = false
+should_print_annotation(::Tuple) = false
+should_print_annotation(::Base.Generator) = false
 
-print_child_key(io::IO, key) = show(io, key)
-print_child_key(io::IO, key::CartesianIndex) = show(io, Tuple(key))
+end # module Multiline
+
+
+module Inline
+
+Base.@kwdef mutable struct State
+    depth::Int = 0
+    precedence::Int = 0 # precedence of the parent expression
+end
+
+Base.@kwdef struct Color
+    delimiter::Symbol = :light_black
+    annotation_delim::Symbol = :light_black
+    brackets::Vector{Symbol} = [:yellow, :green, :cyan, :red, :magenta, :blue]
+end
+
+struct Printer{IO_t <: IO}
+    io::IO_t
+    color::Color
+    state::State
+end
+
+function Printer(io::IO; color::Color = Color())
+    Printer(io, color, State())
+end
+
+function (p::Printer)(node)
+    c = p.color
+    print(xs...) = Base.print(p.io, xs...)
+    printstyled(xs...;kw...) = Base.printstyled(p.io, xs...; kw...)
+    print_prefix(node) = Inline.print_prefix(p.io, node)
+    print_suffix(node) = Inline.print_suffix(p.io, node)
+    print_node(node) = Inline.print_node(p.io, node)
+    print_child_annotation_before(node, child, annotation) = Inline.print_child_annotation_before(p.io, node, child, annotation)
+    print_child_annotation_after(node, child, annotation) = Inline.print_child_annotation_after(p.io, node, child, annotation)
+
+    function join(xs, delimiter, should_print_annotation = false)
+        for (i, x) in enumerate(xs)
+            if should_print_annotation
+                child, annotation = x
+                print_child_annotation_before(node, child, annotation)
+                p(child)
+                print_child_annotation_after(node, child, annotation)
+            else
+                p(x)
+            end
+            i < length(xs) && printstyled(delimiter; color = c.delimiter)
+        end
+    end
+
+    function bracket(f, left, right)
+        printstyled(left; color = c.brackets[p.state.depth%length(c.brackets) + 1]);
+        p.state.depth += 1 
+        f()
+        p.state.depth -= 1
+        printstyled(right; color = c.brackets[p.state.depth%length(c.brackets) + 1])
+    end
+
+    children = Inline.children(node)
+    this_delim = delimiter(node)
+    this_print_annotation = should_print_annotation(children)
+    this_precedence = precedence(node)
+    parent_precedence = p.state.precedence    
+
+    if this_precedence <= parent_precedence
+        bracket(node_bracket_left(node), node_bracket_right(node)) do
+            print_prefix(node)
+            print_node(node)
+            p.state.precedence = this_precedence
+            join(children, this_delim, this_print_annotation)
+            p.state.precedence = parent_precedence
+            print_suffix(node)
+        end
+    else
+        print_prefix(node)
+        print_node(node)
+        p.state.precedence = this_precedence
+        join(children, this_delim, this_print_annotation)
+        p.state.precedence = parent_precedence
+        print_suffix(node)
+    end
+    return
+end
+
+children(node) = error("unimplemented children method for $(typeof(node))")
+print_node(io::IO, node) = error("unimplemented print_node method for $(typeof(node))")
+print_child_annotation_after(io::IO, node, child, annotation) = error("unimplemented print_annotation_after method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
+
+print_prefix(io::IO, node) = return
+print_suffix(io::IO, node) = return
+print_child_annotation_before(io::IO, node, child, v) = return
+
+precedence(node) = 1
+delimiter(node) = ", "
+node_bracket_left(node) = "("
+node_bracket_right(node) = ")"
+
+should_print_annotation(ch) = applicable(keys, ch)
+should_print_annotation(::AbstractVector) = false
+should_print_annotation(::Tuple) = false
+should_print_annotation(::Base.Generator) = false
+
+end # module Inline
 
 end # module Tree

--- a/src/print/tree.jl
+++ b/src/print/tree.jl
@@ -180,19 +180,18 @@ function (p::Printer)(node)
     c = p.color
     print(xs...) = Base.print(p.io, xs...)
     printstyled(xs...;kw...) = Base.printstyled(p.io, xs...; kw...)
-    print_prefix(node) = Inline.print_prefix(p.io, node)
-    print_suffix(node) = Inline.print_suffix(p.io, node)
     print_node(node) = Inline.print_node(p.io, node)
-    print_child_annotation_before(node, child, annotation) = Inline.print_child_annotation_before(p.io, node, child, annotation)
-    print_child_annotation_after(node, child, annotation) = Inline.print_child_annotation_after(p.io, node, child, annotation)
+    print_node_suffix(node) = Inline.print_node_suffix(p.io, node)
+    print_child_annotation(node, child, annotation) = Inline.print_child_annotation(p.io, node, child, annotation)
+    print_child_annotation_suffix(node, child, annotation) = Inline.print_child_annotation_suffix(p.io, node, child, annotation)
 
     function join(xs, delimiter, should_print_annotation = false)
         for (i, x) in enumerate(xs)
             if should_print_annotation
                 child, annotation = x
-                print_child_annotation_before(node, child, annotation)
+                print_child_annotation(node, child, annotation)
                 p(child)
-                print_child_annotation_after(node, child, annotation)
+                print_child_annotation_suffix(node, child, annotation)
             else
                 p(x)
             end
@@ -216,31 +215,28 @@ function (p::Printer)(node)
 
     if this_precedence <= parent_precedence
         bracket(node_bracket_left(node), node_bracket_right(node)) do
-            print_prefix(node)
             print_node(node)
             p.state.precedence = this_precedence
             join(children, this_delim, this_print_annotation)
             p.state.precedence = parent_precedence
-            print_suffix(node)
+            print_node_suffix(node)
         end
     else
-        print_prefix(node)
         print_node(node)
         p.state.precedence = this_precedence
         join(children, this_delim, this_print_annotation)
         p.state.precedence = parent_precedence
-        print_suffix(node)
+        print_node_suffix(node)
     end
     return
 end
 
 children(node) = error("unimplemented children method for $(typeof(node))")
 print_node(io::IO, node) = error("unimplemented print_node method for $(typeof(node))")
-print_child_annotation_after(io::IO, node, child, annotation) = error("unimplemented print_annotation_after method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
+print_node_suffix(io::IO, node) = return
 
-print_prefix(io::IO, node) = return
-print_suffix(io::IO, node) = return
-print_child_annotation_before(io::IO, node, child, v) = return
+print_child_annotation(io::IO, node, child, annotation) = error("unimplemented print_annotation_after method for ($(typeof(node)), $(typeof(child)), $(typeof(annotation)))")
+print_child_annotation_suffix(io::IO, node, child, annotation) = return
 
 precedence(node) = 1
 delimiter(node) = ", "

--- a/src/print/tree.jl
+++ b/src/print/tree.jl
@@ -161,9 +161,8 @@ Base.@kwdef mutable struct State
 end
 
 Base.@kwdef struct Color
-    delimiter::Symbol = :light_black
-    annotation_delim::Symbol = :light_black
-    brackets::Vector{Symbol} = [:yellow, :green, :cyan, :red, :magenta, :blue]
+    delimiter::Symbol = :light_red
+    brackets::Vector{Symbol} = [:yellow, :green, :cyan, :magenta, :light_gray, :default, :light_red]
 end
 
 struct Printer{IO_t <: IO}

--- a/test/print/tree_inline.jl
+++ b/test/print/tree_inline.jl
@@ -1,0 +1,170 @@
+using MLStyle
+using Expronicon.Tree.Inline
+using Expronicon.Tree.Multiline
+using Expronicon.ADT: @adt
+
+# FCSR: free commutative semiring
+@adt public FCSR begin
+    struct Add
+        dict::Dict{FCSR, Int} = Dict{FCSR, Int}()
+    end
+    struct Mul
+        dict::Dict{FCSR, Int} = Dict{FCSR, Int}()
+    end
+    struct Literal
+        name::Symbol
+    end
+end
+function Base.:(==)(lhs::FCSR, rhs::FCSR)
+    @match (lhs, rhs) begin
+        (Add(d1), Add(d2)) => d1 == d2
+        (Mul(d1), Mul(d2)) => d1 == d2
+        (Literal(n1), Literal(n2)) => n1 == n2
+        _ => false
+    end
+end
+function Base.hash(f::FCSR, h::UInt)
+    @match f begin
+        Add(d) => hash(d, h ⊻ hash(:Add))
+        Mul(d) => hash(d, h ⊻ hash(:Mul))
+        Literal(n) => hash(n, h ⊻ hash(:Literal))
+    end
+end
+function Base.:+(lhs::FCSR, rhs::FCSR)
+    @match (lhs, rhs) begin
+        (Add(d1), Add(d2)) => Add(merge(+, d1, d2))
+        (Add(d), _) => begin
+            d = copy(d)
+            d[rhs] = get(d, rhs, 0) + 1
+            Add(d)
+        end
+        (_, Add(d)) => rhs + lhs
+        _ => begin
+            d = Dict(lhs => 1)
+            d[rhs] = get(d, rhs, 0) + 1
+            Add(d)
+        end
+    end
+end
+function Base.:*(lhs::FCSR, rhs::FCSR)
+    @match (lhs, rhs) begin
+        (Mul(d1), Mul(d2)) => Mul(merge(*, d1, d2))
+        (Mul(d), _) => begin
+            d = copy(d)
+            d[rhs] = get(d, rhs, 0) + 1
+            Mul(d)
+        end
+        (_, Mul(d)) => rhs * lhs
+        _ => begin
+            d = Dict(lhs => 1)
+            d[rhs] = get(d, rhs, 0) + 1
+            Mul(d)
+        end
+    end
+end
+
+# define inline printer for FCSR
+function Inline.children(node::FCSR)
+    @match node begin
+        Add(d) => d
+        Mul(d) => d
+        _ => ()
+    end
+end
+function Inline.print_node(io::IO, node::FCSR)
+    @match node begin
+        Add(d) => return
+        Mul(d) => return
+        Literal(n) => printstyled(io, n; color = :green)
+    end
+end
+function Inline.print_child_annotation_after(io::IO, node::FCSR, child::FCSR, annotation)
+    @match (node, child) begin
+        (Mul(d), _) => begin
+            annotation == 1 && return
+            print(io, superscriptnumber(annotation))
+        end
+        _ => return
+    end
+end
+function Inline.print_child_annotation_before(io::IO, node::FCSR, child::FCSR, annotation)
+    @match (node, child) begin
+        (Add(d), _) => begin
+            annotation == 1 && return
+            printstyled(io, annotation; color = :light_black)
+        end
+        _ => return
+    end
+end
+function Inline.delimiter(node::FCSR)
+    @match node begin
+        Add(d) => return " ⊕ "
+        Mul(d) => return " ⊙ "
+        _ => return ""
+    end
+end
+function Inline.precedence(node::FCSR)
+    @match node begin
+        Add(d) => return 1
+        Mul(d) => return 2
+        _ => return 3
+    end
+end
+function superscriptnumber(i::Int)
+    if i < 0
+        c = [Char(0x207B)]
+    else
+        c = []
+    end
+    for d in reverse(digits(abs(i)))
+        if d == 0 push!(c, Char(0x2070)) end
+        if d == 1 push!(c, Char(0x00B9)) end
+        if d == 2 push!(c, Char(0x00B2)) end
+        if d == 3 push!(c, Char(0x00B3)) end
+        if d > 3 push!(c, Char(0x2070+d)) end
+    end
+    return join(c)
+end
+
+# define multiline printer for FCSR
+function Multiline.children(node::FCSR)
+    @match node begin
+        Add(d) => d
+        Mul(d) => d
+        _ => ()
+    end
+end
+function Multiline.print_node(io::IO, node::FCSR)
+    @match node begin
+        Add(d) => printstyled(io, "Add"; color = :cyan, bold = true)
+        Mul(d) => printstyled(io, "Mul"; color = :cyan, bold = true)
+        Literal(n) => begin
+            printstyled(io, "Literal("; color = :cyan, bold = true)
+            printstyled(io, n; color = :green)
+            printstyled(io, ")"; color = :cyan, bold = true)
+        end
+    end
+end
+function Multiline.print_child_annotation(io::IO, node::FCSR, child::FCSR, annotation)
+    @match (node, child) begin
+        (Add(d), _) || (Mul(d), _) => printstyled(io, annotation; color = :light_black)
+        _ => return
+    end
+end
+
+x, y, z = map(Literal, [:x, :y, :z])
+a = x + y
+b = x + z
+ex = a * a * b + a * b * b
+
+inline_printer = Inline.Printer(stdout)
+inline_printer(a)
+inline_printer(b)
+inline_printer(a+b)
+inline_printer(ex)
+
+multiline_printer = Multiline.Printer(stdout)
+multiline_printer(a)
+multiline_printer(b)
+multiline_printer(a+b)
+multiline_printer(ex)

--- a/test/print/tree_inline.jl
+++ b/test/print/tree_inline.jl
@@ -78,7 +78,7 @@ function Inline.print_node(io::IO, node::FCSR)
         Literal(n) => printstyled(io, n; color = :green)
     end
 end
-function Inline.print_child_annotation_after(io::IO, node::FCSR, child::FCSR, annotation)
+function Inline.print_child_annotation_suffix(io::IO, node::FCSR, child::FCSR, annotation)
     @match (node, child) begin
         (Mul(d), _) => begin
             annotation == 1 && return
@@ -87,7 +87,7 @@ function Inline.print_child_annotation_after(io::IO, node::FCSR, child::FCSR, an
         _ => return
     end
 end
-function Inline.print_child_annotation_before(io::IO, node::FCSR, child::FCSR, annotation)
+function Inline.print_child_annotation(io::IO, node::FCSR, child::FCSR, annotation)
     @match (node, child) begin
         (Add(d), _) => begin
             annotation == 1 && return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,8 @@ end
     include("print/inline.jl")
     include("print/multi.jl")
     include("print/old.jl")
-    include("print/tree.jl")
+    include("print/tree_multi.jl")
+    include("print/tree_inline.jl")
 
     @static if VERSION > v"1.8-"
         include("print/lts.jl")


### PR DESCRIPTION
This PR includes inline tree printer for ADT.

`test/print/tree_inline.jl` gives an example of inline printer for a free commutative semiring.