### PR TITLE
BREAKING(feat): use private namespace for variants by default

### DIFF
--- a/lib/ZhanKai/src/ZhanKai.jl
+++ b/lib/ZhanKai/src/ZhanKai.jl
@@ -1,7 +1,7 @@
 module ZhanKai
 
 using Expronicon: Substitute, print_expr, sprint_expr, rm_lineinfo, rm_nothing, rm_single_block, canonicalize_lambda_head
-using Expronicon.ADT: @adt
+using Expronicon.ADT: @adt, @use
 using Configurations: @option, Maybe
 using MLStyle: @match, @switch, @case
 using Glob: @glob_str, GlobMatch, glob

--- a/lib/ZhanKai/src/ignore/ignore.jl
+++ b/lib/ZhanKai/src/ignore/ignore.jl
@@ -3,7 +3,7 @@ module GitIgnore
 export IgnoreFile, parse, @pattern_str
 
 using MLStyle: @match, @switch, @case
-using Expronicon.ADT: ADT, @adt
+using Expronicon.ADT: ADT, @adt, @use
 using Glob: FilenameMatch
 
 include("types.jl")

--- a/lib/ZhanKai/src/ignore/ignore.jl
+++ b/lib/ZhanKai/src/ignore/ignore.jl
@@ -3,7 +3,7 @@ module GitIgnore
 export IgnoreFile, parse, @pattern_str
 
 using MLStyle: @match, @switch, @case
-using Expronicon.ADT: ADT, @adt
+using Expronicon.ADT: ADT, @adt, @export_use
 using Glob: FilenameMatch
 
 include("types.jl")

--- a/lib/ZhanKai/src/ignore/ignore.jl
+++ b/lib/ZhanKai/src/ignore/ignore.jl
@@ -3,7 +3,7 @@ module GitIgnore
 export IgnoreFile, parse, @pattern_str
 
 using MLStyle: @match, @switch, @case
-using Expronicon.ADT: ADT, @adt, @export_use
+using Expronicon.ADT: ADT, @adt
 using Glob: FilenameMatch
 
 include("types.jl")

--- a/lib/ZhanKai/src/ignore/ignore.jl
+++ b/lib/ZhanKai/src/ignore/ignore.jl
@@ -3,7 +3,7 @@ module GitIgnore
 export IgnoreFile, parse, @pattern_str
 
 using MLStyle: @match, @switch, @case
-using Expronicon.ADT: ADT, @adt, @use
+using Expronicon.ADT: ADT, @adt, @export_use
 using Glob: FilenameMatch
 
 include("types.jl")

--- a/lib/ZhanKai/src/ignore/types.jl
+++ b/lib/ZhanKai/src/ignore/types.jl
@@ -1,4 +1,4 @@
-@adt public Pattern begin
+@adt Pattern begin
     Comment(::String)
     
     Root
@@ -17,6 +17,8 @@
         segments::Vector{Pattern}
     end
 end
+
+@use Pattern: *
 
 struct IgnoreFile
     path::String

--- a/lib/ZhanKai/src/ignore/types.jl
+++ b/lib/ZhanKai/src/ignore/types.jl
@@ -18,7 +18,7 @@
     end
 end
 
-@use Pattern: *
+@export_use Pattern: *
 
 struct IgnoreFile
     path::String

--- a/src/adt/adt.jl
+++ b/src/adt/adt.jl
@@ -10,6 +10,7 @@ include("traits.jl")
 include("types.jl")
 include("emit.jl")
 include("match.jl")
+include("use.jl")
 include("print.jl")
 
 end # ADT

--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -264,8 +264,20 @@ function emit_variant_binding(def::ADTTypeDef, info::EmitInfo)
             end
         end
     end
+
+    @static VERSION < v"1.8-"
+        builtin_names = (
+            :name, :super, :parameters, :types, :names, :instance,
+            :layout, :size, :ninitialized, :hash, :abstract, :mutable, :hasfreetypevars,
+            :isconcretetype, :isdispatchtuple, :isbitstype, :zeroinit, :isinlinealloc,
+            :has_concrete_subtype, :cached_by_hash
+        )
+    else
+        builtin_names = (:name, :super, :parameters, :types, :instance, :layout, :size, :hash, :flags)
+    end
+
     body.otherwise = quote
-        if name in (:name, :super, :parameters, :types, :instance, :layout, :size, :hash, :flags)
+        if name in $builtin_names
             $Base.getfield(Self, name)
         else
             throw(ArgumentError("invalid variant type"))

--- a/src/adt/emit.jl
+++ b/src/adt/emit.jl
@@ -265,7 +265,7 @@ function emit_variant_binding(def::ADTTypeDef, info::EmitInfo)
         end
     end
 
-    @static VERSION < v"1.8-"
+    @static if VERSION < v"1.8-"
         builtin_names = (
             :name, :super, :parameters, :types, :names, :instance,
             :layout, :size, :ninitialized, :hash, :abstract, :mutable, :hasfreetypevars,

--- a/src/adt/print.jl
+++ b/src/adt/print.jl
@@ -45,6 +45,10 @@ function Base.show(io::IO, ::MIME"text/plain", def::Variant)
     indent = get(io, :indent, 0)
     print(io, tab(indent))
 
+    if def.public
+        printstyled(io, "@public "; color=197)
+    end
+
     if def.type == :singleton
         print(io, def.name)
     elseif def.type == :call

--- a/src/adt/print.jl
+++ b/src/adt/print.jl
@@ -11,7 +11,6 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", def::ADTTypeDef)
     printstyled(io, "@adt "; color=:cyan)
-    def.export_variants && printstyled(io, "public "; color=197)
     def.m === Main || print(io, def.m, ".")
     print(io, def.name)
     if !isempty(def.typevars)
@@ -44,10 +43,6 @@ end
 function Base.show(io::IO, ::MIME"text/plain", def::Variant)
     indent = get(io, :indent, 0)
     print(io, tab(indent))
-
-    if def.public
-        printstyled(io, "@public "; color=197)
-    end
 
     if def.type == :singleton
         print(io, def.name)

--- a/src/adt/reflection.jl
+++ b/src/adt/reflection.jl
@@ -20,10 +20,13 @@ function emit_reflection(def::ADTTypeDef, info::EmitInfo)
     end
 end
 
-function emit_variants(def::ADTTypeDef, ::EmitInfo)
+function emit_variants(def::ADTTypeDef, info::EmitInfo)
+    variant_types = map(enumerate(def.variants)) do (idx, _)
+        xvariant_type(info, idx)
+    end
     return quote
         function $ADT.variants(::Type{<:$(def.name)})
-            return $(xtuple(map(x->x.name, def.variants)...))
+            return $(xtuple(variant_types...))
         end
     end
 end

--- a/src/adt/use.jl
+++ b/src/adt/use.jl
@@ -41,8 +41,15 @@ function variant_names_to_bind(mod::Module, expr::Expr)
     end
 end
 
+function assert_defined(mod::Module, variants::Vector{Symbol})
+    for variant in variants
+        isdefined(mod, variant) && error("cannot import $variant: it already exists")
+    end
+end
+
 function use_m(mod::Module, expr::Expr)
     name, variants = variant_names_to_bind(mod, expr)
+    assert_defined(mod, variants)
     return expr_map(variants) do variant_name
         :(const $variant_name = $name.$variant_name)
     end
@@ -50,6 +57,7 @@ end
 
 function export_use_m(mod::Module, expr::Expr)
     name, variants = variant_names_to_bind(mod, expr)
+    assert_defined(mod, variants)
     return expr_map(variants) do variant_name
         quote
             export $variant_name

--- a/src/adt/use.jl
+++ b/src/adt/use.jl
@@ -58,10 +58,14 @@ end
 function export_use_m(mod::Module, expr::Expr)
     name, variants = variant_names_to_bind(mod, expr)
     assert_defined(mod, variants)
-    return expr_map(variants) do variant_name
+    body = expr_map(variants) do variant_name
         quote
             export $variant_name
             const $variant_name = $name.$variant_name
         end
+    end
+    return quote
+        export $name
+        $body
     end
 end

--- a/src/adt/use.jl
+++ b/src/adt/use.jl
@@ -1,0 +1,59 @@
+"""
+    @use <name>: <variant>
+    @use <name>: <variant>, <variant>, ...
+    @use <name>: *
+
+Import the variant of a ADT into current namespace.
+
+```julia
+@use Message: Write
+```
+"""
+macro use(expr)
+    esc(use_m(__module__, expr))
+end
+
+"""
+    @export_use <name>: <variant>
+
+Import the variant of a ADT into current namespace,
+and export it.
+    
+```julia
+@export_use Message: Write
+```
+"""
+macro export_use(expr)
+    esc(export_use_m(__module__, expr))
+end
+
+function variant_names_to_bind(mod::Module, expr::Expr)
+    return @match expr begin
+        :($(name::Symbol):*) => begin
+            isdefined(mod, name) || throw(UndefVarError(name))
+            (name, variant_typename.(
+                variants(getproperty(mod, name))
+            ))
+        end
+        :($(name::Symbol):$(variant::Symbol)) || :($(name::Symbol).$(variant::Symbol)) => (name, (variant, ))
+        Expr(:tuple, :($(name::Symbol):$(variant::Symbol)), xs...) => (name, (variant, xs...))
+        _ => throw(ArgumentError("expect @use <name>: <variant> or @use <name>: *"))
+    end
+end
+
+function use_m(mod::Module, expr::Expr)
+    name, variants = variant_names_to_bind(mod, expr)
+    return expr_map(variants) do variant_name
+        :(const $variant_name = $name.$variant_name)
+    end
+end
+
+function export_use_m(mod::Module, expr::Expr)
+    name, variants = variant_names_to_bind(mod, expr)
+    return expr_map(variants) do variant_name
+        quote
+            export $variant_name
+            const $variant_name = $name.$variant_name
+        end
+    end
+end

--- a/src/adt/use.jl
+++ b/src/adt/use.jl
@@ -41,7 +41,7 @@ function variant_names_to_bind(mod::Module, expr::Expr)
     end
 end
 
-function assert_defined(mod::Module, variants::Vector{Symbol})
+function assert_defined(mod::Module, variants)
     for variant in variants
         isdefined(mod, variant) && error("cannot import $variant: it already exists")
     end

--- a/test/adt/emit.jl
+++ b/test/adt/emit.jl
@@ -1,6 +1,6 @@
 using Test
 using Expronicon
-using Expronicon.ADT: ADT, EmitInfo, ADTTypeDef, @adt, emit_struct, emit_exports,
+using Expronicon.ADT: ADT, EmitInfo, ADTTypeDef, @adt, @use, emit_struct,
     emit_show, emit_variant_cons, emit_reflection, emit_variant_binding,
     emit_getproperty, emit_propertynames,
     # reflection
@@ -32,7 +32,7 @@ body = quote
 
     Write(::String)
 
-    @public struct Aka
+    struct Aka
         x::Vector{Int64}
         y::Vector{Int64}
     end
@@ -82,7 +82,6 @@ end
 
 def = ADTTypeDef(Main, :Message, body)
 info = EmitInfo(def)
-@test_expr emit_exports(def, info) == :(export Quit, Move, Write, Aka, ChangeColor, Message)
 
 @test_expr emit_struct(def, info) == quote
     #= /Users/roger/Code/Julia/Expronicon/src/adt/emit.jl:329 =# Core.@__doc__ struct Message
@@ -276,7 +275,7 @@ end
 
 @test_expr emit_variants(def, info) == quote
     function (Expronicon.ADT).variants(::Type{<:Message})
-        return (Quit, Move, Write, Aka, ChangeColor)
+        return (Core.bitcast(var"Message#Type", 0x00000001), Core.bitcast(var"Message#Type", 0x00000002), Core.bitcast(var"Message#Type", 0x00000003), Core.bitcast(var"Message#Type", 0x00000004), Core.bitcast(var"Message#Type", 0x00000005))
     end
 end
 
@@ -468,29 +467,29 @@ end
     end
 end
 
-@test_expr emit_variant_binding(def, info) == quote
-    const Quit = Message(Core.bitcast(var"Message#Type", 0x00000001))
-    const Move = Core.bitcast(var"Message#Type", 0x00000002)
-    const Write = Core.bitcast(var"Message#Type", 0x00000003)
-    const Aka = Core.bitcast(var"Message#Type", 0x00000004)
-    const ChangeColor = Core.bitcast(var"Message#Type", 0x00000005)
-    function Base.show(io::IO, t::var"Message#Type")
-        if t == Core.bitcast(var"Message#Type", 0x00000001)
-            print(io, "Message", "::", "Quit")
-        elseif t == Core.bitcast(var"Message#Type", 0x00000002)
-            print(io, "Message", "::", "Move")
-        elseif t == Core.bitcast(var"Message#Type", 0x00000003)
-            print(io, "Message", "::", "Write")
-        elseif t == Core.bitcast(var"Message#Type", 0x00000004)
-            print(io, "Message", "::", "Aka")
-        elseif t == Core.bitcast(var"Message#Type", 0x00000005)
-            print(io, "Message", "::", "ChangeColor")
-        else
-            throw(ArgumentError("invalid variant type"))
-        end
-        return
-    end
-end
+# @test_expr emit_variant_binding(def, info) == quote
+#     const Quit = Message(Core.bitcast(var"Message#Type", 0x00000001))
+#     const Move = Core.bitcast(var"Message#Type", 0x00000002)
+#     const Write = Core.bitcast(var"Message#Type", 0x00000003)
+#     const Aka = Core.bitcast(var"Message#Type", 0x00000004)
+#     const ChangeColor = Core.bitcast(var"Message#Type", 0x00000005)
+#     function Base.show(io::IO, t::var"Message#Type")
+#         if t == Core.bitcast(var"Message#Type", 0x00000001)
+#             print(io, "Message", "::", "Quit")
+#         elseif t == Core.bitcast(var"Message#Type", 0x00000002)
+#             print(io, "Message", "::", "Move")
+#         elseif t == Core.bitcast(var"Message#Type", 0x00000003)
+#             print(io, "Message", "::", "Write")
+#         elseif t == Core.bitcast(var"Message#Type", 0x00000004)
+#             print(io, "Message", "::", "Aka")
+#         elseif t == Core.bitcast(var"Message#Type", 0x00000005)
+#             print(io, "Message", "::", "ChangeColor")
+#         else
+#             throw(ArgumentError("invalid variant type"))
+#         end
+#         return
+#     end
+# end
 
 
 @adt MubanLang begin
@@ -509,6 +508,8 @@ end
         stmts::Vector{MubanLang}
     end
 end
+
+@use MubanLang:*
 
 @testset "variant as field type" begin
     @test Reference(Id(:x), Id(:y), None).some == None

--- a/test/adt/emit.jl
+++ b/test/adt/emit.jl
@@ -32,14 +32,13 @@ body = quote
 
     Write(::String)
 
-    struct Aka
+    @public struct Aka
         x::Vector{Int64}
         y::Vector{Int64}
     end
 
     ChangeColor(::Int64, ::Int64, ::Int64)
 end
-
 
 @testset "EmitInfo(::ADTTypeDef)" begin
     def = ADTTypeDef(Main, :Message, body)

--- a/test/adt/enum.jl
+++ b/test/adt/enum.jl
@@ -2,7 +2,7 @@ module TestEnum
 
 using Test
 using MLStyle
-using Expronicon.ADT: ADT, @adt, ADTTypeDef, EmitInfo,
+using Expronicon.ADT: ADT, @adt, @use, ADTTypeDef, EmitInfo,
     emit_variant_cons, variant_fieldnames, variant_masks,
     variant_type, variants, variant_typename, adt_type
 
@@ -13,6 +13,8 @@ using Expronicon.ADT: ADT, @adt, ADTTypeDef, EmitInfo,
     InvalidChannelType(::Int, ::Char)
     ChannelTypeTooLong(::Int)
 end
+
+@use AddressMaskErr: *
 
 @testset "singleton enum match" begin
     e = BinLengthNotMatch(1, 2)

--- a/test/adt/evals/test_eval_pulse.jl
+++ b/test/adt/evals/test_eval_pulse.jl
@@ -1,7 +1,7 @@
 module TestEvalPulse
 
 using Test
-using Expronicon.ADT: @adt
+using Expronicon.ADT: @adt, @use
 
 @adt PulseLang begin
     struct Waveform
@@ -11,6 +11,8 @@ using Expronicon.ADT: @adt
         duration::Float64
     end
 end
+
+@use PulseLang.Waveform
 
 wf = Waveform([1.0, 2.0], trues(2), 1, 1.0)
 @testset "eval(PulseLang)" begin

--- a/test/adt/evals/test_export.jl
+++ b/test/adt/evals/test_export.jl
@@ -1,9 +1,9 @@
 module TestExport
 
 using Test
-using Expronicon.ADT: @adt
+using Expronicon.ADT: @adt, @export_use
 
-@adt public PulseLang begin
+@adt PulseLang begin
     struct Waveform
         coeff::Vector{Float64}
         mask::BitVector
@@ -11,6 +11,9 @@ using Expronicon.ADT: @adt
         duration::Float64
     end
 end
+
+export PulseLang
+@export_use PulseLang: *
 
 @testset "TestExport" begin
     @test :PulseLang in names(TestExport)

--- a/test/adt/evals/test_isequal.jl
+++ b/test/adt/evals/test_isequal.jl
@@ -2,7 +2,7 @@ module TestIsEqualEnum
 
 using Test
 using MLStyle
-using Expronicon.ADT: @adt, variant_type
+using Expronicon.ADT: @adt, @use, variant_type
 
 @adt Foo begin
     Bar
@@ -10,6 +10,8 @@ using Expronicon.ADT: @adt, variant_type
         args::Vector{Int}
     end
 end
+
+@use Foo: *
 
 function Base.:(==)(lhs::Foo, rhs::Foo)
     @match (lhs, rhs) begin

--- a/test/adt/evals/test_kwstruct.jl
+++ b/test/adt/evals/test_kwstruct.jl
@@ -17,12 +17,12 @@ using Expronicon.ADT: @adt
 end
 
 @testset "KwStruct" begin
-    a = A()
+    a = AT.A()
     @test a.common_field == 0
     @test a.a == true
     @test a.b == 10
 
-    b = B()
+    b = AT.B()
     @test b.a == 1
     @test b.foo == sin(1)
 end

--- a/test/adt/evals/test_singleton.jl
+++ b/test/adt/evals/test_singleton.jl
@@ -11,10 +11,10 @@ using Expronicon.ADT: @adt
 end
 
 @testset "singleton" begin
-    @match Apple begin
-        Apple => @test true
-        Orange => @test false
-        Banana => @test false
+    @match Food.Apple begin
+        &Food.Apple => @test true
+        &Food.Orange => @test false
+        &Food.Banana => @test false
     end
 end
 

--- a/test/adt/match.jl
+++ b/test/adt/match.jl
@@ -99,13 +99,13 @@ end
     end
 end
 
-@use Muban:*
+@use Muban: Loop, Id, InlineExpr, Template
 
 @testset "variant type match" begin
-    x = Loop([Id("i"), Id("j")], InlineExpr(1, [Id("a"), Id("b")]), Template([]))
+    x = Muban.Loop([Id("i"), Id("j")], InlineExpr(1, [Id("a"), Id("b")]), Template([]))
 
     @match x begin
-        Text(s) => @test s == "abc"
+        Muban.Text(s) => @test s == "abc"
         Loop(indices, iterator, body) => @test true
         _ => @test false
     end

--- a/test/adt/match.jl
+++ b/test/adt/match.jl
@@ -2,7 +2,7 @@ module TestMatch
 
 using Test
 using MLStyle
-using Expronicon.ADT: ADT, @adt, ADTTypeDef, EmitInfo,
+using Expronicon.ADT: ADT, @adt, @use, ADTTypeDef, EmitInfo,
     emit_variant_cons, variant_fieldnames, variant_masks,
     variant_type, variants, variant_typename, adt_type
 
@@ -18,6 +18,8 @@ using Expronicon.ADT: ADT, @adt, ADTTypeDef, EmitInfo,
 
     ChangeColor(::Int, ::Int, ::Int)
 end
+
+@use Message:*
 
 @testset "basic patterns" begin
     @test 3 == @match Move(1, 2) begin
@@ -96,6 +98,8 @@ end
         body::Template # Template
     end
 end
+
+@use Muban:*
 
 @testset "variant type match" begin
     x = Loop([Id("i"), Id("j")], InlineExpr(1, [Id("a"), Id("b")]), Template([]))

--- a/test/adt/tree.jl
+++ b/test/adt/tree.jl
@@ -1,11 +1,13 @@
 using MLStyle
-using Expronicon.ADT: @adt
+using Expronicon.ADT: @adt, @use
 using Expronicon.ADT.Tree
 
-@adt public DeviceKind begin
+@adt DeviceKind begin
     CPU
     GPU(::Int)
 end
+
+@use DeviceKind: *
 
 function Base.:(==)(lhs::DeviceKind, rhs::DeviceKind)
     @match (lhs, rhs) begin
@@ -22,10 +24,12 @@ function Base.hash(d::DeviceKind, h::UInt)
     end
 end
 
-@adt public Size begin
+@adt Size begin
     ConstSize(::Int)
     VarSize(::String)
 end
+
+@use Size: *
 
 function Base.:(==)(lhs::Size, rhs::Size)
     @match (lhs, rhs) begin
@@ -49,7 +53,7 @@ end
 Base.convert(::Type{Size}, s::String) = VarSize(s)
 Base.convert(::Type{Size}, s::Int) = ConstSize(s)
 
-@adt public Tensura begin
+@adt Tensura begin
     struct Tensor
         name::String
         dims::Vector{Size}
@@ -92,6 +96,8 @@ Base.convert(::Type{Size}, s::Int) = ConstSize(s)
         device::DeviceKind
     end
 end
+
+@use Tensura: *
 
 function Tree.children(t::Tensura)
     @match t begin

--- a/test/adt/tree_inline.jl
+++ b/test/adt/tree_inline.jl
@@ -1,11 +1,11 @@
 
 using MLStyle
-using Expronicon.ADT: @adt
+using Expronicon.ADT: @adt, @use
 using Expronicon.ADT.Tree.Inline
 using Expronicon.ADT.Tree
 
 # FSR: free semiring
-@adt public FSR begin
+@adt FSR begin
     struct Add
         dict::Dict{FSR, Int} = Dict{FSR, Int}()
     end
@@ -16,6 +16,9 @@ using Expronicon.ADT.Tree
         name::Symbol
     end
 end
+
+@use FSR: *
+
 function Base.:(==)(lhs::FSR, rhs::FSR)
     @match (lhs, rhs) begin
         (Add(d1), Add(d2)) => d1 == d2


### PR DESCRIPTION
this PR changes the default behavior on how we bring variants into the namespace, by default

```julia
@adt Message begin
    Quit

    struct Move
        x::Int64
        y::Int64
    end

    Write(::String)

    struct Aka
        x::Vector{Int64}
        y::Vector{Int64}
    end

    ChangeColor(::Int64, ::Int64, ::Int64)
end
```

will not create constant bindings as `Quit`, `Move` etc. but will instead overload `getproperty` on the `Message` type as

```julia
Base.getproperty(::Type{Message}, name::Symbol)
```

so that `Message.Quit` will return the corresponding variant type, on the other hand, we provide a separate macro `@use` that has a similar syntax as `using` to allow users to import variants into their current namespace based on their needs, e.g

```julia
@use Message: * # import all into namespace
@use Message.Aka # import Aka only
@use Message: Aka # import Aka only
```

and another macro `@use_export` with the same syntax, not only imports the variant into the namespace, but it will also export the name in the module.

This will be breaking, but should make similar variants more distinguishable, any comments? @ChenZhao44 @weinbe58