### PR TITLE
Support unparenthesised, single parameter, anonymous functions

### DIFF
--- a/src/analysis/split.jl
+++ b/src/analysis/split.jl
@@ -48,10 +48,11 @@ function split_function_head(ex::Expr; source = nothing)
         Expr(:call, name, args...) => (name, args, nothing, nothing, nothing)
         Expr(:block, x, ::LineNumberNode, Expr(:(=), kw, value)) => (nothing, Any[x], Any[Expr(:kw, kw, value)], nothing, nothing)
         Expr(:block, x, ::LineNumberNode, kw) => (nothing, Any[x], Any[kw], nothing, nothing)
-        Expr(:(::), call, rettype) => begin
+        Expr(:(::), call::Expr, rettype) => begin
             name, args, kw, whereparams, _ = split_function_head(call)
             (name, args, kw, whereparams, rettype)
         end
+        Expr(:(::), arg::Symbol, argtype) || Expr(:(::), argtype) => (nothing, Any[ex], nothing, nothing, nothing)
         Expr(:where, call, whereparams...) => begin
             name, args, kw, _, rettype = split_function_head(call)
             (name, args, kw, whereparams, rettype)
@@ -59,6 +60,7 @@ function split_function_head(ex::Expr; source = nothing)
         _ => throw(SyntaxError("expect a function head, got $ex", source))
     end
 end
+split_function_head(s::Symbol; source = nothing) = (nothing, Any[s], nothing, nothing, nothing)
 
 """
     split_struct_name(ex::Expr) -> name, typevars, supertype

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -143,6 +143,15 @@ end
     end
 
     @test_expr JLFunction f(x::Int)::Int = x
+
+    ex = :(x->2x)
+    @test JLFunction(ex).args == Any[:x]
+
+    ex = :(x::Int->2x)
+    @test JLFunction(ex).args == Any[:(x::Int)]
+
+    ex = :(::Int -> 0)
+    @test JLFunction(ex).args == Any[:(::Int)]
 end
 
 @testset "JLStruct(ex)" begin


### PR DESCRIPTION
These changes add support for anonymous functions of these shapes, all of which are valid Julia, but to be parsed as `JLFunction`s:

- `x::Int->2x`
- `::Int -> 0`
- `x->2x`

`:(::)`-expressions with two arguments should only be split further when the first argument is itself an `Expr`. That is generated by function calls of the shape `(x,)::RT -> $body`, in which case the `(x,)` is the `call` which should be split.

But Julia also generates two argument `:(::)`-expressions for functions of shape `x::T -> $body`. In this case the first argument is `:x`, and the second is `:T`. `:x` can't be split further, and so the whole matching `ex`, `x::T`, should be returned as the only argument.

For functions of shape `::T -> $body`, an `:(::)`-expression with only one argument, `:T` is generated, which should be handled in the same way as above.

The last missing piece is the more common shape `x->$body`. These functions only has a single symbol `:x` as the first argument of the resulting `->`-expression. To handle this case, a new method for `split_function_head` was added.