### PR TITLE
Correct behavior of is_function

### DIFF
--- a/src/analysis/check.jl
+++ b/src/analysis/check.jl
@@ -151,10 +151,12 @@ function is_function(@nospecialize(def))
                 source = line
             end
             # TODO: generated expressions 
-            head, call, body = _split_function_nothrow(expr)
+            split_function_tuple =  split_function_nothrow(expr)
+            isnothing(split_function_tuple) && return false
+            head, call, body = split_function_tuple
             split_head_tuple = @match head begin
-                :(->) => _split_anonymous_function_head_nothrow(call)
-                h => _split_function_head_nothrow(call; source)
+                :(->) => split_anonymous_function_head_nothrow(call)
+                h => split_function_head_nothrow(call)
             end
             isnothing(split_head_tuple) && return false 
             name, args, kw, whereparams, rettype = split_head_tuple

--- a/src/analysis/check.jl
+++ b/src/analysis/check.jl
@@ -145,9 +145,22 @@ Check if given object is a function expression.
 function is_function(@nospecialize(def))
     @match def begin
         ::JLFunction => true
-        Expr(:function, _, _) => true
-        Expr(:(=), _, _) => true
-        Expr(:(->), _, _) => true
+        ::Expr => begin
+            line, doc, expr = split_doc(def)
+            if !isnothing(doc)
+                source = line
+            end
+            # TODO: generated expressions 
+            head, call, body = _split_function_nothrow(expr)
+            split_head_tuple = @match head begin
+                :(->) => _split_anonymous_function_head_nothrow(call)
+                h => _split_function_head_nothrow(call; source)
+            end
+            isnothing(split_head_tuple) && return false 
+            name, args, kw, whereparams, rettype = split_head_tuple
+
+            true 
+        end
         _ => false
     end
 end

--- a/src/analysis/split.jl
+++ b/src/analysis/split.jl
@@ -27,13 +27,20 @@ end
 Split function head declaration with function body.
 """
 function split_function(ex::Expr; source = nothing)
+    ret = _split_function_nothrow(ex)
+    isnothing(ret) && throw(SyntaxError("expect a function expr, got $ex", source))
+    ret
+end
+
+function _split_function_nothrow(ex::Expr)
     @match ex begin
         Expr(:function, call, body) => (:function, call, body)
         Expr(:(=), call, body) => (:(=), call, body)
         Expr(:(->), call, body) => (:(->), call, body)
-        _ => throw(SyntaxError("expect a function expr, got $ex", source))
+        _ => nothing
     end
 end
+
 
 """
     split_function_head(ex::Expr) -> name, args, kw, whereparams, rettype
@@ -41,6 +48,12 @@ end
 Split function head to name, arguments, keyword arguments and where parameters.
 """
 function split_function_head(ex::Expr; source=nothing)
+    split_head_tuple = _split_function_nothrow(ex)
+    isnothing(split_head_tuple) && throw(SyntaxError("expect a function head, got $ex", source))
+    split_head_tuple
+end
+
+function _split_function_head_nothrow(ex::Expr)
     @match ex begin
         Expr(:tuple, Expr(:parameters, kw...), args...) => (nothing, args, kw, nothing, nothing)
         Expr(:tuple, args...) => (nothing, args, nothing, nothing, nothing)
@@ -49,17 +62,21 @@ function split_function_head(ex::Expr; source=nothing)
         Expr(:block, x, ::LineNumberNode, Expr(:(=), kw, value)) => (nothing, Any[x], Any[Expr(:kw, kw, value)], nothing, nothing)
         Expr(:block, x, ::LineNumberNode, kw) => (nothing, Any[x], Any[kw], nothing, nothing)
         Expr(:(::), call::Expr, rettype) => begin
-            name, args, kw, whereparams, _ = split_function_head(call)
+            sub_tuple = _split_function_head_nothrow(call)
+            isnothing(sub_tuple) && return nothing
+            name, args, kw, whereparams, _ = _split_function_head_nothrow(call)
             (name, args, kw, whereparams, rettype)
         end
         Expr(:where, call, whereparams...) => begin
-            name, args, kw, _, rettype = split_function_head(call)
+            sub_tuple = _split_function_head_nothrow(call)
+            isnothing(sub_tuple) && return nothing
+            name, args, kw, _, rettype = sub_tuple
             (name, args, kw, whereparams, rettype)
         end
-        _ => throw(SyntaxError("expect a function head, got $ex", source))
+        _ => nothing
     end
 end
-split_function_head(s::Symbol; source=nothing) = (nothing, Any[s], nothing, nothing, nothing)
+_split_function_head_nothrow(s::Symbol) = (nothing, Any[s], nothing, nothing, nothing)
 
 """
     split_anonymous_function_head(ex::Expr) -> nothing, args, kw, whereparams, rettype
@@ -67,24 +84,35 @@ split_function_head(s::Symbol; source=nothing) = (nothing, Any[s], nothing, noth
 Split anonymous function head to arguments, keyword arguments and where parameters.
 """
 function split_anonymous_function_head(ex::Expr; source=nothing)
+    split_head_tuple = _split_function_head_nothrow(ex)
+    isnothing(split_head_tuple) && throw(SyntaxError("expect an anonymous function head, got $ex", source))
+    split_head_tuple
+end
+
+function _split_anonymous_function_head_nothrow(ex::Expr)
     @match ex begin
         Expr(:tuple, Expr(:parameters, kw...), args...) => (nothing, args, kw, nothing, nothing)
         Expr(:tuple, args...) => (nothing, args, nothing, nothing, nothing)
         Expr(:block, x, ::LineNumberNode, Expr(:(=), kw, value)) => (nothing, Any[x], Any[Expr(:kw, kw, value)], nothing, nothing)
         Expr(:block, x, ::LineNumberNode, kw) => (nothing, Any[x], Any[kw], nothing, nothing)
         Expr(:(::), fh::Expr, rettype) => begin
-            name, args, kw, whereparams, _ = split_anonymous_function_head(fh)
+            sub_tuple = _split_anonymous_function_head_nothrow(fh)
+            isnothing(sub_tuple) && return nothing
+            name, args, kw, whereparams, _ = sub_tuple
             (name, args, kw, whereparams, rettype)
         end
         Expr(:(::), arg::Symbol, argtype) || Expr(:(::), argtype) => (nothing, Any[ex], nothing, nothing, nothing)
         Expr(:where, call, whereparams...) => begin
-            name, args, kw, _, rettype = split_anonymous_function_head(call)
+            sub_tuple = _split_anonymous_function_head_nothrow(call)
+            isnothing(sub_tuple) && return nothing
+            name, args, kw, _, rettype = sub_tuple
             (name, args, kw, whereparams, rettype)
         end
-        _ => throw(SyntaxError("expect an anonymous function head, got $ex", source))
+        _ => nothing
     end
 end
-split_anonymous_function_head(s::Symbol; source=nothing) = (nothing, Any[s], nothing, nothing, nothing)
+_split_anonymous_function_head_nothrow(s::Symbol) = (nothing, Any[s], nothing, nothing, nothing)
+
 
 """
     split_struct_name(ex::Expr) -> name, typevars, supertype

--- a/src/analysis/split.jl
+++ b/src/analysis/split.jl
@@ -89,7 +89,7 @@ function split_anonymous_function_head(ex::Expr; source=nothing)
     split_head_tuple
 end
 
-split_anonymous_function_head(ex::Expr; source=nothing) = 
+split_anonymous_function_head(ex::Symbol; source=nothing) = 
     split_anonymous_function_head_nothrow(ex)
 
 function split_anonymous_function_head_nothrow(ex::Expr)


### PR DESCRIPTION
Before: 
```
julia> is_function(:(x -> x + 2))
true

julia> is_function(:(foo(x) -> x + 2))
true
```

Now:
```
julia> is_function(:(x -> x + 2))
true

julia> is_function(:(foo(x) -> x + 2))
false
```


I need this for pattern matching in cases where I do not want to throw exceptions in the LHS of a MLStyle `@match` pattern, when constructing a `JLFunction`, because I'm using https://github.com/iamed2/ResultTypes.jl - throwing from `JLFunction` constructor makes sense, but not in my case, because if the pattern fails for some reason, it's throwing an exception and I have to wrap my `@match` block in a `try-catch` expression and then wrap the exception in a `ResultType`, which may also catch other exceptions and is not a good pattern.

Can we consider using https://github.com/iamed2/ResultTypes.jl in the library?

The workaround is to use `ex::Expr && if is_function(ex) end => (jlf = JLFunction(ex); do_stuff(jlf.body)` instead of `JLFunction(; head = :(->), args, body, rettype) => do_stuff(body)` 
 


Missing tests.